### PR TITLE
docs/connect-to-local-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@
 4. Ensure emulator is ready or mobile device is connected to your machine
 5. `yarn` or `npm install`
 6. `yarn android` or `npm run android`
+
+## Connecting to local server
+
+For debugging end-to-end, sometimes it's good to connect to a local a server.
+Assuming local server is running on `ws://localhost:8080` (see hooligram-server README on how to run server locally):
+
+1. set `API_HOST=ws://localhost:8080` in `.env` file
+2. run emulator
+3. `adb tcp:8080 tcp:8080`
+4. `yarn android`
+5. check out the client-side & server logs and you should see that they are interacting with other!

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## Connecting to local hooligram-server
 
 For debugging end-to-end, sometimes it's good to connect to a local a hooligram-server.
-Assuming local server is running on `ws://localhost:8080` (see the README at the [hooligram-server](https://github.com/hooligram/hooligram-server) repo on how to run the server locally):
+Assuming a local server is running on `ws://localhost:8080` (see the README at the [hooligram-server](https://github.com/hooligram/hooligram-server) repo on how to run the server locally):
 
 1. set `API_HOST=ws://localhost:8080` in `.env` file
 2. run emulator

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 5. `yarn` or `npm install`
 6. `yarn android` or `npm run android`
 
-## Connecting to local server
+## Connecting to local hooligram-server
 
-For debugging end-to-end, sometimes it's good to connect to a local a server.
-Assuming local server is running on `ws://localhost:8080` (see hooligram-server README on how to run server locally):
+For debugging end-to-end, sometimes it's good to connect to a local a hooligram-server.
+Assuming local server is running on `ws://localhost:8080` (see the README at the [hooligram-server](https://github.com/hooligram/hooligram-server) repo on how to run the server locally):
 
 1. set `API_HOST=ws://localhost:8080` in `.env` file
 2. run emulator

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ Assuming local server is running on `ws://localhost:8080` (see the README at the
 2. run emulator
 3. `adb tcp:8080 tcp:8080`
 4. `yarn android`
-5. check out the client-side & server logs and you should see that they are interacting with other!
+5. check out the client-side & server logs and you should see that they are interacting with each other!

--- a/app/hooligram-api/__tests__/hooligramApi.test.js
+++ b/app/hooligram-api/__tests__/hooligramApi.test.js
@@ -13,7 +13,9 @@ describe('hooligramApi', () => {
 
       expect(store.dispatch).toHaveBeenCalledWith({
         type: 'WEBSOCKET:INIT_SUCCESS',
-        payload: {}
+        payload: {
+          host: config.host
+        }
       })
     })
   })

--- a/app/hooligram-api/hooligramApi.js
+++ b/app/hooligram-api/hooligramApi.js
@@ -16,7 +16,7 @@ const hooligramApi = (config) => (store) => {
   ws = new WebSocket(host)
 
   ws.onopen = () => {
-    dispatch(websocketInitSuccess())
+    dispatch(websocketInitSuccess(host))
   }
 
   ws.onmessage = (event) => {

--- a/app/state/actions/websocket.js
+++ b/app/state/actions/websocket.js
@@ -10,10 +10,12 @@ export const websocketInitRequest = () => {
   }
 }
 
-export const websocketInitSuccess = () => {
+export const websocketInitSuccess = (host) => {
   return {
     type: WEBSOCKET_INIT_SUCCESS,
-    payload: {}
+    payload: {
+      host
+    }
   }
 }
 


### PR DESCRIPTION
#35 

1. add instruction to README
2. `WEBSOCKET:INIT_SUCCESS` action includes `host` in payload for debugging purpose