### PR TITLE
bugfix: should go to conversation

### DIFF
--- a/app/persistence-api/__tests__/persistence-api.test.js
+++ b/app/persistence-api/__tests__/persistence-api.test.js
@@ -21,7 +21,7 @@ describe('persistence-api', () => {
 
       it('should return state from storage', async () => {
         const state = await PersistenceApi.getState()
-  
+
         expect(state).toEqual({
           mockedData: 'mockedData'
         })
@@ -44,10 +44,10 @@ describe('persistence-api', () => {
         }))
         PersistenceApi = require('@persistence-api/persistence-api').default
       })
-  
+
       it('should return `undefined`', async () => {
         const state = await PersistenceApi.getState()
-  
+
         expect(state).toEqual(undefined)
       })
     })
@@ -88,8 +88,8 @@ describe('persistence-api', () => {
     describe('state is not serializable', () => {
       let state
       beforeEach(() => {
-        state = {};
-        state.myself = state;
+        state = {}
+        state.myself = state
       })
 
       it('should throw error', async done => {
@@ -106,8 +106,8 @@ describe('persistence-api', () => {
     describe('Storage fails to save', () => {
       let state
       beforeEach(() => {
-        AsyncStorage.setItem = jest.fn(() => 
-          new Promise((_, reject) => 
+        AsyncStorage.setItem = jest.fn(() =>
+          new Promise((_, reject) =>
             reject()
           )
         )

--- a/app/screens/Conversation/Conversation.js
+++ b/app/screens/Conversation/Conversation.js
@@ -65,7 +65,7 @@ export default class Conversation extends Component {
             <MessageWriter/>
           </View>
         </KeyboardAvoidingView>
-        <ImageBackground 
+        <ImageBackground
           source={require('@resources/images/conversation-background.jpg')}
           style={styles.background}/>
       </React.Fragment>

--- a/app/state/middlewares/navigation/navigation.js
+++ b/app/state/middlewares/navigation/navigation.js
@@ -1,7 +1,9 @@
 import {
+  PERSISTENCE_LOAD_STATE_SUCCESS,
   PERSISTENCE_SAVE_STATE_SUCCESS,
   VERIFICATION_SUBMIT_CODE_SUCCESS,
-  VERIFICATION_REQUEST_CODE_SUCCESS
+  VERIFICATION_REQUEST_CODE_SUCCESS,
+  WEBSOCKET_INIT_SUCCESS
 } from '@state/actions'
 import { getFullRouteName } from '@state/middlewares/navigation/utils'
 
@@ -29,6 +31,30 @@ const middleware = navigationActions => store => next => action => {
         navigator.dispatch(
           navigationActions.navigate({
             routeName: 'RequestCode'
+          })
+        )
+      }
+
+      if ([PERSISTENCE_LOAD_STATE_SUCCESS, WEBSOCKET_INIT_SUCCESS].includes(action.type)) {
+        const {
+          app: {
+            websocketOnline
+          },
+          authorization: {
+            country_code,
+            phone_number,
+            token
+          }
+        } = nextState
+
+        if (!websocketOnline) return
+        if (!country_code) return
+        if (!phone_number) return
+        if (!token) return
+
+        navigator.dispatch(
+          navigationActions.navigate({
+            routeName: 'Conversation'
           })
         )
       }
@@ -90,7 +116,7 @@ const middleware = navigationActions => store => next => action => {
       break
     }
 
-    default: 
+    default:
       break
   }
 

--- a/app/state/middlewares/navigation/utils.js
+++ b/app/state/middlewares/navigation/utils.js
@@ -1,4 +1,3 @@
-
 export const getFullRouteName = (navigator) => {
   const {
     state: {

--- a/app/state/reducers/app/__tests__/app.test.js
+++ b/app/state/reducers/app/__tests__/app.test.js
@@ -1,0 +1,51 @@
+import appReducer from '@state/reducers/app/app'
+
+describe('app reducer', () => {
+  let state
+
+  describe('initialization', () => {
+    beforeEach(() => {
+      state = appReducer(undefined, {})
+    })
+
+    it('should return correct initial state', () => {
+      expect(state).toEqual(
+        {
+          websocketOnline: false
+        }
+      )
+    })
+
+    it('should set websocketOnline to true', () => {
+      const nextState = appReducer(state, {
+        type: 'WEBSOCKET:INIT_SUCCESS'
+      })
+
+      expect(nextState).toEqual(
+        {
+          websocketOnline: true
+        }
+      )
+    })
+  })
+
+  describe('websocket is online', () => {
+    beforeEach(() => {
+      state = {
+        websocketOnline: true
+      }
+    })
+
+    it('should set websocketOnline to false', () => {
+      const nextState = appReducer(state, {
+        type: 'WEBSOCKET:CLOSE'
+      })
+
+      expect(nextState).toEqual(
+        {
+          websocketOnline: false
+        }
+      )
+    })
+  })
+})

--- a/app/state/reducers/app/app.js
+++ b/app/state/reducers/app/app.js
@@ -1,4 +1,5 @@
 import {
+  WEBSOCKET_CLOSE,
   WEBSOCKET_INIT_SUCCESS
 } from '@state/actions'
 
@@ -8,6 +9,13 @@ export const initialState = {
 
 const app = (state = initialState, action) => {
   switch (action.type) {
+    case WEBSOCKET_CLOSE: {
+      return {
+        ...state,
+        websocketOnline: false
+      }
+    }
+
     case WEBSOCKET_INIT_SUCCESS: {
       return {
         ...state,

--- a/app/state/reducers/app/app.js
+++ b/app/state/reducers/app/app.js
@@ -1,0 +1,24 @@
+import {
+  WEBSOCKET_INIT_SUCCESS
+} from '@state/actions'
+
+export const initialState = {
+  websocketOnline: false,
+}
+
+const app = (state = initialState, action) => {
+  switch (action.type) {
+    case WEBSOCKET_INIT_SUCCESS: {
+      return {
+        ...state,
+        websocketOnline: true
+      }
+    }
+
+    default: {
+      return state
+    }
+  }
+}
+
+export default app

--- a/app/state/reducers/app/index.js
+++ b/app/state/reducers/app/index.js
@@ -1,0 +1,3 @@
+import app from '@state/reducers/app/app'
+
+export default app

--- a/app/state/reducers/index.js
+++ b/app/state/reducers/index.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux'
-import app from '@state/reducers/app';
+import app from '@state/reducers/app'
 import authorization from '@state/reducers/authorization'
 import forms from './forms'
 import profile from './profile'

--- a/app/state/reducers/index.js
+++ b/app/state/reducers/index.js
@@ -1,10 +1,12 @@
 import { combineReducers } from 'redux'
+import app from '@state/reducers/app';
 import authorization from '@state/reducers/authorization'
 import forms from './forms'
 import profile from './profile'
 import messages from '@state/reducers/messages'
 
 export default combineReducers({
+  app,
   authorization,
   forms,
   messages,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-import { AppRegistry } from 'react-native';
-import { name as appName } from './app.json';
-import App from './app/index';
+import { AppRegistry } from 'react-native'
+import { name as appName } from './app.json'
+import App from './app/index'
 
-AppRegistry.registerComponent(appName, () => App);
+AppRegistry.registerComponent(appName, () => App)


### PR DESCRIPTION
The app should go to the `Conversation` screen instead of doing onboarding all over again if the user has already registered.

Changes:
- 78dfedc - Add `websocketOnline` state since we should only go to the screen if this is true
- 696462d - The triggers are `PERSISTENCE_LOAD_STATE_SUCCESS` & `WEBSOCKET_INIT_SUCCESS` since:
  - `country_code`, `phone_number` & `token` comes from `PERSISTENCE_LOAD_STATE_SUCCESS`
  - `websocketOnline` comes from `WEBSOCKET_INIT_SUCCESS`

Fixes #53.