### PR TITLE
generate signed apk

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,19 @@ Assuming a local server is running on `ws://localhost:8080` (see the README at t
 3. `adb tcp:8080 tcp:8080`
 4. `yarn android`
 5. check out the client-side & server logs and you should see that they are interacting with each other!
+
+## Generating signed APK
+
+1. Fill up `android/gradle.properties` details.
+
+   ```env
+   RELEASE_KEY_ALIAS=*******
+   RELEASE_KEY_PASSWORD=*******
+   RELEASE_STORE_FILE=*******
+   RELEASE_STORE_PASSWORD=*******
+   ```
+
+2. Put `hooligram.keystore` file in `android/app` directory.
+3. `cd android`
+4. `./gradlew assembleRelease`
+5. Find the APK here `android/app/build/outputs/apk/release/app-release.apk`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hooligram-client
+# Hooligram React Native Android App
 
 ## How to run
 
@@ -10,28 +10,28 @@
    API_HOST=ws://<domain>:<port>/<end-point>
    ```
 
-   To connect to a localhost server, use `10.0.2.2` as `<domain>` (for emulators)
+   To connect to a localhost server, use `10.0.2.2` as `<domain>` (for emulators).
 
-4. Ensure emulator is ready or mobile device is connected to your machine
+4. Ensure emulator is ready or mobile device is connected to your machine.
 5. `yarn` or `npm install`
 6. `yarn android` or `npm run android`
 
 ### Remote debugging on a real device
 
 1. `adb reverse tcp:8081 tcp:8081`
-2. Open [React Native Debugger](https://github.com/jhen0409/react-native-debugger)
-3. _**Shake**_ the device & select _Debug JS Remotely_
+2. Open [React Native Debugger](https://github.com/jhen0409/react-native-debugger).
+3. _**Shake**_ the device & select _Debug JS Remotely_.
 
 ## Connecting to local hooligram-server
 
 For debugging end-to-end, sometimes it's good to connect to a local a hooligram-server.
 Assuming a local server is running on `ws://localhost:8080` (see the README at the [hooligram-server](https://github.com/hooligram/hooligram-server) repo on how to run the server locally):
 
-1. set `API_HOST=ws://localhost:8080` in `.env` file
-2. run emulator
+1. Set `API_HOST=ws://localhost:8080` in `.env` file.
+2. Run the emulator.
 3. `adb tcp:8080 tcp:8080`
 4. `yarn android`
-5. check out the client-side & server logs and you should see that they are interacting with each other!
+5. Check out the client & the server logs. You should see that they are interacting with each other!
 
 ## Generating signed APK
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -108,6 +108,16 @@ android {
             abiFilters "armeabi-v7a", "x86"
         }
     }
+    signingConfigs {
+        release {
+            if (project.hasProperty('RELEASE_STORE_FILE')) {
+                storeFile file(RELEASE_STORE_FILE)
+                storePassword RELEASE_STORE_PASSWORD
+                keyAlias RELEASE_KEY_ALIAS
+                keyPassword RELEASE_KEY_PASSWORD
+            }
+        }
+    }
     splits {
         abi {
             reset()
@@ -120,6 +130,7 @@ android {
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            signingConfig signingConfigs.release
         }
     }
     // applicationVariants are e.g. debug, release

--- a/android/app/hooligram.keystore.example
+++ b/android/app/hooligram.keystore.example
@@ -1,0 +1,1 @@
+Put the legit hooligram.keystore in this directory.

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -16,3 +16,8 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+RELEASE_KEY_ALIAS=*******
+RELEASE_KEY_PASSWORD=*******
+RELEASE_STORE_FILE=*******
+RELEASE_STORE_PASSWORD=*******


### PR DESCRIPTION
Fixes #75 & #67.

It seems that _websocket_ will sometime fail to capture events from the backend on development mode. Testing the app as a standalone seems to resolve #67.